### PR TITLE
Fixed the bug, that issued the bottom circle to be displayed wrong.

### DIFF
--- a/lib/src/main/java/com/orangegangsters/github/swipyrefreshlayout/library/SwipyRefreshLayout.java
+++ b/lib/src/main/java/com/orangegangsters/github/swipyrefreshlayout/library/SwipyRefreshLayout.java
@@ -1046,16 +1046,16 @@ public class SwipyRefreshLayout extends ViewGroup {
         mCircleView.bringToFront();
         mCircleView.offsetTopAndBottom(offset);
 
-        switch (mDirection) {
-            case BOTTOM:
-                mCurrentTargetOffsetTop = getMeasuredHeight() - mCircleView.getMeasuredHeight();
-                break;
-            case TOP:
-            default:
-                mCurrentTargetOffsetTop  = mCircleView.getTop();
-                break;
-        }
-//        mCurrentTargetOffsetTop = mCircleView.getTop();
+//        switch (mDirection) {
+//            case BOTTOM:
+//                mCurrentTargetOffsetTop = getMeasuredHeight() - mCircleView.getMeasuredHeight();
+//                break;
+//            case TOP:
+//            default:
+//                mCurrentTargetOffsetTop  = mCircleView.getTop();
+//                break;
+//        }
+        mCurrentTargetOffsetTop = mCircleView.getTop();
         if (requiresUpdate && android.os.Build.VERSION.SDK_INT < 11) {
             invalidate();
         }


### PR DESCRIPTION
While using your extended variation of SwipeRefreshLayout, I run into the bug. While pulling from bottom (using Direction.BOTH) the circle indicator with arrow moved out of the screen pretty fast. I compared your code with SwipeRefreshLayoutBottom and noticed, that the offset is calculated a bit diffrent way. I brought it back, how it was at initial version and everything worked. Correct me, if I missed something.
