### PR TITLE
Fix appear position of bottom refresh indicator.

### DIFF
--- a/lib/src/main/java/com/orangegangsters/github/swipyrefreshlayout/library/SwipyRefreshLayout.java
+++ b/lib/src/main/java/com/orangegangsters/github/swipyrefreshlayout/library/SwipyRefreshLayout.java
@@ -592,7 +592,7 @@ public class SwipyRefreshLayout extends ViewGroup {
 
             switch (mDirection) {
                 case BOTTOM:
-                    mCurrentTargetOffsetTop = mOriginalOffsetTop = getMeasuredHeight() - mCircleView.getMeasuredHeight();
+                    mCurrentTargetOffsetTop = mOriginalOffsetTop = getMeasuredHeight();
                     break;
                 case TOP:
                 default:
@@ -1094,8 +1094,7 @@ public class SwipyRefreshLayout extends ViewGroup {
 
         switch (mDirection) {
             case BOTTOM:
-                mCurrentTargetOffsetTop = getMeasuredHeight() - mCircleView.getMeasuredHeight();
-                mOriginalOffsetTop = getMeasuredHeight() - mCircleView.getMeasuredHeight();
+                mCurrentTargetOffsetTop = mOriginalOffsetTop = getMeasuredHeight();
                 break;
             case TOP:
             default:
@@ -1113,8 +1112,7 @@ public class SwipyRefreshLayout extends ViewGroup {
         mDirection = direction;
         switch (mDirection) {
             case BOTTOM:
-                mCurrentTargetOffsetTop = getMeasuredHeight() - mCircleView.getMeasuredHeight();
-                mOriginalOffsetTop = getMeasuredHeight() - mCircleView.getMeasuredHeight();
+                mCurrentTargetOffsetTop = mOriginalOffsetTop = getMeasuredHeight();
                 break;
             case TOP:
             default:


### PR DESCRIPTION
The bottom refresh indicator appears on the bottom edge, but the top refresh indicator appears above the top edge which is outside.
This pull request fixes the bottom refresh indicator's appear position to below the bottom edge which same as the top one.
