### PR TITLE
Fix for manifest merge issue.

### DIFF
--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.orangegangsters.github.swipyrefreshlayout.library">
 
-    <application android:allowBackup="true">
+    <application >
 
     </application>
 


### PR DESCRIPTION
can't use android:allowBackup="false" in manifest...

Error:Execution failed for task ':app:processDevDebugManifest'.

> Manifest merger failed : Attribute application@allowBackup value=(false) from AndroidManifest.xml:19:9-36
>     is also present at [com.github.orangegangsters:swipy:1.2.2] AndroidManifest.xml:11:18-44 value=(true).
>     Suggestion: add 'tools:replace="android:allowBackup"' to <application> element at AndroidManifest.xml:17:5-59:19 to override.
