### PR TITLE
Fix for issue #40 For short refreshes, spinner animation never really stops, completely freezes fragment in which it is used.

### DIFF
--- a/lib/src/main/java/com/orangegangsters/github/swipyrefreshlayout/library/MaterialProgressDrawable.java
+++ b/lib/src/main/java/com/orangegangsters/github/swipyrefreshlayout/library/MaterialProgressDrawable.java
@@ -53,6 +53,7 @@ class MaterialProgressDrawable extends Drawable implements Animatable {
     private static final Interpolator END_CURVE_INTERPOLATOR = new EndCurveInterpolator();
     private static final Interpolator START_CURVE_INTERPOLATOR = new StartCurveInterpolator();
     private static final Interpolator EASE_INTERPOLATOR = new AccelerateDecelerateInterpolator();
+    private boolean stopped;
 
     @Retention(RetentionPolicy.CLASS)
     @IntDef({LARGE, DEFAULT})
@@ -138,8 +139,6 @@ class MaterialProgressDrawable extends Drawable implements Animatable {
      * Set the overall size for the progress spinner. This updates the radius
      * and stroke width of the ring.
      *
-     * @param size One of {@link com.orangegangsters.github.swiperefreshlayout.MaterialProgressDrawable.LARGE} or
-     *            {@link com.orangegangsters.github.swiperefreshlayout.MaterialProgressDrawable.DEFAULT}
      */
     public void updateSizes(@ProgressDrawableSize int size) {
         if (size == LARGE) {
@@ -268,6 +267,7 @@ class MaterialProgressDrawable extends Drawable implements Animatable {
 
     @Override
     public void start() {
+        stopped = false;
         mAnimation.reset();
         mRing.storeOriginals();
         // Already showing some part of the ring
@@ -282,6 +282,7 @@ class MaterialProgressDrawable extends Drawable implements Animatable {
 
     @Override
     public void stop() {
+        stopped = true;
         mParent.clearAnimation();
         setRotation(0);
         mRing.setShowArrow(false);
@@ -317,6 +318,9 @@ class MaterialProgressDrawable extends Drawable implements Animatable {
 
             @Override
             public void onAnimationEnd(Animation animation) {
+                if (stopped) {
+                    return;
+                }
                 ring.goToNextColor();
                 ring.storeOriginals();
                 ring.setShowArrow(false);

--- a/lib/src/main/java/com/orangegangsters/github/swipyrefreshlayout/library/MaterialProgressDrawable.java
+++ b/lib/src/main/java/com/orangegangsters/github/swipyrefreshlayout/library/MaterialProgressDrawable.java
@@ -139,6 +139,8 @@ class MaterialProgressDrawable extends Drawable implements Animatable {
      * Set the overall size for the progress spinner. This updates the radius
      * and stroke width of the ring.
      *
+     * @param size One of {@link #LARGE} or
+     *            {@link #DEFAULT}
      */
     public void updateSizes(@ProgressDrawableSize int size) {
         if (size == LARGE) {


### PR DESCRIPTION
See this video https://www.dropbox.com/s/k1m53u8zyjb2s3w/SwipyRefreshLayout_issue_40.mp4?dl=0 of me reproducing the issue where the spinning animation doesn't stop, which you can see the second time I pull down. After the activity restart is when I've applied this fix, and you can see the circle doesn't keep spinning anymore like before.

Also a small Javadoc fix.
